### PR TITLE
fix rpc_proxy and rpc_worker & enhance RPC interface

### DIFF
--- a/tensorrt_llm/executor/rpc/__init__.py
+++ b/tensorrt_llm/executor/rpc/__init__.py
@@ -1,9 +1,10 @@
 from .rpc_client import RPCClient
-from .rpc_common import (RPCCancelled, RPCError, RPCRequest, RPCResponse,
-                         RPCStreamingError, RPCTimeout)
+from .rpc_common import (RPCCancelled, RPCError, RPCParams, RPCRequest,
+                         RPCResponse, RPCStreamingError, RPCTimeout)
 from .rpc_server import RPCServer, Server
 
 __all__ = [
     "RPCClient", "RPCServer", "Server", "RPCError", "RPCTimeout",
-    "RPCCancelled", "RPCStreamingError", "RPCRequest", "RPCResponse"
+    "RPCCancelled", "RPCStreamingError", "RPCRequest", "RPCResponse",
+    "RPCParams"
 ]

--- a/tensorrt_llm/executor/rpc/rpc_client.py
+++ b/tensorrt_llm/executor/rpc/rpc_client.py
@@ -201,7 +201,6 @@ class RPCClient:
         timeout = rpc_params.timeout if rpc_params.timeout is not None else self._timeout
 
         request_id = uuid.uuid4().hex
-        logger_debug(f"RPC client sending request: {request_id}")
         request = RPCRequest(request_id,
                              method_name,
                              args,

--- a/tensorrt_llm/executor/rpc/rpc_client.py
+++ b/tensorrt_llm/executor/rpc/rpc_client.py
@@ -4,6 +4,7 @@ import threading
 import uuid
 from typing import Any, AsyncIterator, Dict, Optional
 
+from ...llmapi.utils import AsyncQueue, _SyncQueue, logger_debug
 from ...logger import logger
 from ..ipc import ZeroMqQueue
 from .rpc_common import (RPCCancelled, RPCParams, RPCRequest, RPCResponse,
@@ -34,7 +35,7 @@ class RPCClient:
                                           use_hmac_encryption=False)
         self._pending_futures = {}
         # map request_id to the queue for streaming responses
-        self._streaming_queues: Dict[str, asyncio.Queue] = {}
+        self._streaming_queues: Dict[str, AsyncQueue] = {}
         self._reader_task = None
         self._executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=num_workers, thread_name_prefix="rpc_client_worker")
@@ -45,7 +46,7 @@ class RPCClient:
         self._loop = None
         self._loop_thread = None
 
-        logger.debug(f"RPC Client initialized. Connected to {self._address}")
+        logger_debug(f"RPC Client initialized. Connected to {self._address}")
 
     def shutdown_server(self):
         """Shutdown the server."""
@@ -64,7 +65,7 @@ class RPCClient:
         # stop the main loop
         self._closed = True
 
-        logger.debug("RPC Client closing")
+        logger_debug("RPC Client closing")
 
         if self._stop_event and self._loop:
             # Use call_soon_threadsafe since set() is not a coroutine
@@ -79,7 +80,7 @@ class RPCClient:
                 self._reader_task.cancel()
             except Exception as e:
                 # Task might have already finished or been cancelled
-                logger.debug(f"Reader task cleanup: {e}")
+                logger_debug(f"Reader task cleanup: {e}")
             self._reader_task = None
 
         if self._loop and self._loop.is_running():
@@ -94,7 +95,7 @@ class RPCClient:
             self._client_socket.close()
             self._client_socket = None
 
-        logger.debug("RPC Client closed")
+        logger_debug("RPC Client closed")
 
     async def _response_reader(self):
         """Task to read responses from the socket and set results on futures."""
@@ -111,7 +112,7 @@ class RPCClient:
                     # Timeout is expected - just check stop event and continue
                     continue
 
-                logger.debug(f"RPC Client received response: {response}")
+                logger_debug(f"RPC Client received response: {response}")
 
                 # Handle streaming responses
                 if response.is_streaming:
@@ -120,38 +121,51 @@ class RPCClient:
                     ], f"Invalid stream status: {response.stream_status}"
                     queue = self._streaming_queues.get(response.request_id)
                     if queue:
-                        await queue.put(response)
+                        # put to the sync queue, as the current event loop is
+                        # different from the one in call_async or call_streaming
+                        assert isinstance(queue, AsyncQueue)
+                        logger_debug(
+                            f"RPC Client putting response to AsyncQueue: {response}"
+                        )
+                        queue.sync_q.put(response)
                         # Clean up if stream ended
                         if response.stream_status in ['end', 'error']:
                             self._streaming_queues.pop(response.request_id,
                                                        None)
                 else:
                     # Handle regular responses
-                    future = self._pending_futures.get(response.request_id)
-                    if future and not future.done():
-                        if response.error is None:
-                            future.set_result(response.result)
-                        else:
-                            # Use the original RPCError from the response
-                            future.set_exception(response.error)
+                    if future_info := self._pending_futures.get(
+                            response.request_id):
+                        future, target_loop = future_info
+
+                        if not future.done():
+                            if response.error is None:
+                                target_loop.call_soon_threadsafe(
+                                    future.set_result, response.result)
+                            else:
+                                # Use the original RPCError from the response
+                                target_loop.call_soon_threadsafe(
+                                    future.set_exception, response.error)
                     self._pending_futures.pop(response.request_id, None)
 
             except asyncio.CancelledError:
                 # Still handle cancellation for backward compatibility
-                logger.debug("Response reader cancelled")
+                logger_debug("Response reader cancelled")
                 break
             except Exception as e:
                 logger.error(f"Exception in RPC response reader: {e}")
                 # Propagate exception to all pending futures
-                for future in self._pending_futures.values():
+                for (future, target_loop) in self._pending_futures.values():
+
                     if not future.done():
-                        future.set_exception(e)
+                        target_loop.call_soon_threadsafe(
+                            future.set_exception, e)
                 # Also signal error to streaming queues
                 for queue in self._streaming_queues.values():
                     await queue.put(RPCResponse("", None, e, False, 0, 'error'))
                 break
 
-        logger.debug("Response reader exiting gracefully")
+        logger_debug("Response reader exiting gracefully")
         self._reader_task = None
 
     def _start_response_reader_lazily(self):
@@ -175,7 +189,7 @@ class RPCClient:
         Returns:
             The result of the remote method call
         """
-        logger.debug(
+        logger_debug(
             f"RPC client calling method: {method_name} with args: {args} and kwargs: {kwargs}"
         )
         if self._server_stopped:
@@ -187,14 +201,14 @@ class RPCClient:
         timeout = rpc_params.timeout if rpc_params.timeout is not None else self._timeout
 
         request_id = uuid.uuid4().hex
-        logger.debug(f"RPC client sending request: {request_id}")
+        logger_debug(f"RPC client sending request: {request_id}")
         request = RPCRequest(request_id,
                              method_name,
                              args,
                              kwargs,
                              need_response,
                              timeout=timeout)
-        logger.debug(f"RPC client sending request: {request}")
+        logger_debug(f"RPC client sending request: {request}")
         await self._client_socket.put_async(request)
 
         if not need_response:
@@ -202,7 +216,7 @@ class RPCClient:
 
         loop = asyncio.get_running_loop()
         future = loop.create_future()
-        self._pending_futures[request_id] = future
+        self._pending_futures[request_id] = (future, loop)
 
         try:
             # If timeout, the remote call should return a timeout error timely,
@@ -339,7 +353,11 @@ class RPCClient:
         timeout = rpc_params.timeout if rpc_params.timeout is not None else self._timeout
 
         request_id = uuid.uuid4().hex
-        queue = asyncio.Queue()
+        # Use AsyncQueue to ensure proper cross-thread communication
+        queue = AsyncQueue()
+        # Recreate sync_q with the current running loop for proper cross-thread communication
+        # This ensures the background _response_reader thread can properly notify this event loop
+        queue._sync_q = _SyncQueue(queue, asyncio.get_running_loop())
         self._streaming_queues[request_id] = queue
 
         try:
@@ -355,16 +373,24 @@ class RPCClient:
 
             # Read streaming responses
             while True:
+                logger_debug(f"RPC Client call_streaming waiting for response",
+                             color="green")
                 if timeout is None:
                     response = await queue.get()
                 else:
                     response = await asyncio.wait_for(queue.get(),
                                                       timeout=timeout + 1)
 
+                logger_debug(
+                    f"RPC Client call_streaming received [{response.stream_status}] response: {response}",
+                    color="green")
                 if response.stream_status == 'start':
                     # Start of stream
                     continue
                 elif response.stream_status == 'data':
+                    logger_debug(
+                        f"RPC Client call_streaming received data: {response.result}",
+                        color="green")
                     # Yield data
                     yield response.result
                 elif response.stream_status == 'end':

--- a/tensorrt_llm/executor/rpc/rpc_client.py
+++ b/tensorrt_llm/executor/rpc/rpc_client.py
@@ -2,11 +2,11 @@ import asyncio
 import concurrent.futures
 import threading
 import uuid
-from typing import Any, AsyncIterator, Dict
+from typing import Any, AsyncIterator, Dict, Optional
 
 from ...logger import logger
 from ..ipc import ZeroMqQueue
-from .rpc_common import (RPCCancelled, RPCRequest, RPCResponse,
+from .rpc_common import (RPCCancelled, RPCParams, RPCRequest, RPCResponse,
                          RPCStreamingError, RPCTimeout)
 
 
@@ -18,7 +18,7 @@ class RPCClient:
     def __init__(self,
                  address: str,
                  hmac_key=None,
-                 timeout: float = 10,
+                 timeout: Optional[float] = None,
                  num_workers: int = 4):
         '''
         Args:
@@ -164,33 +164,32 @@ class RPCClient:
             # Store the concurrent.futures.Future
             self._reader_task = future
 
-    async def _call_async(self, __rpc_method_name, *args, **kwargs):
+    async def _call_async(self, method_name, *args, **kwargs):
         """Async version of RPC call.
         Args:
-            __rpc_method_name: Method name to call
+            method_name: Method name to call
             *args: Positional arguments
             **kwargs: Keyword arguments
-            __rpc_timeout: The timeout (seconds) for the RPC call.
-            __rpc_need_response: Whether the RPC call needs a response.
-                If set to False, the remote call will return immediately.
+            __rpc_params: RPCParams object containing RPC parameters.
 
         Returns:
             The result of the remote method call
         """
         logger.debug(
-            f"RPC client calling method: {__rpc_method_name} with args: {args} and kwargs: {kwargs}"
+            f"RPC client calling method: {method_name} with args: {args} and kwargs: {kwargs}"
         )
         if self._server_stopped:
             raise RPCCancelled("Server is shutting down, request cancelled")
 
         self._start_response_reader_lazily()
-        need_response = kwargs.pop("__rpc_need_response", True)
-        timeout = kwargs.pop("__rpc_timeout", self._timeout)
+        rpc_params = kwargs.pop("__rpc_params", RPCParams())
+        need_response = rpc_params.need_response
+        timeout = rpc_params.timeout if rpc_params.timeout is not None else self._timeout
 
         request_id = uuid.uuid4().hex
         logger.debug(f"RPC client sending request: {request_id}")
         request = RPCRequest(request_id,
-                             __rpc_method_name,
+                             method_name,
                              args,
                              kwargs,
                              need_response,
@@ -209,14 +208,17 @@ class RPCClient:
             # If timeout, the remote call should return a timeout error timely,
             # so we add 1 second to the timeout to ensure the client can get
             # that result.
-            res = await asyncio.wait_for(future, timeout + 1)
+            if timeout is None:
+                res = await future
+            else:
+                res = await asyncio.wait_for(future, timeout + 1)
             return res
         except RPCCancelled:
             self._server_stopped = True
             raise
         except asyncio.TimeoutError:
             raise RPCTimeout(
-                f"Request '{__rpc_method_name}' timed out after {timeout}s")
+                f"Request '{method_name}' timed out after {timeout}s")
         except Exception as e:
             raise e
         finally:
@@ -241,11 +243,11 @@ class RPCClient:
             import time
             time.sleep(0.1)
 
-    def _call_sync(self, __rpc_method_name, *args, **kwargs):
+    def _call_sync(self, method_name, *args, **kwargs):
         """Synchronous version of RPC call."""
         self._ensure_event_loop()
         future = asyncio.run_coroutine_threadsafe(
-            self._call_async(__rpc_method_name, *args, **kwargs), self._loop)
+            self._call_async(method_name, *args, **kwargs), self._loop)
         return future.result()
 
     def call_async(self, name: str, *args, **kwargs):
@@ -263,7 +265,9 @@ class RPCClient:
         Example:
             result = await client.call_async('remote_method', arg1, arg2, key=value)
         """
-        return self._call_async(name, *args, **kwargs, __rpc_need_response=True)
+        if "__rpc_params" not in kwargs:
+            kwargs["__rpc_params"] = RPCParams(need_response=True)
+        return self._call_async(name, *args, **kwargs)
 
     def call_future(self, name: str, *args,
                     **kwargs) -> concurrent.futures.Future:
@@ -331,7 +335,8 @@ class RPCClient:
             raise RPCCancelled("Server is shutting down, request cancelled")
 
         self._start_response_reader_lazily()
-        timeout = kwargs.pop("__rpc_timeout", self._timeout)
+        rpc_params = kwargs.pop("__rpc_params", RPCParams())
+        timeout = rpc_params.timeout if rpc_params.timeout is not None else self._timeout
 
         request_id = uuid.uuid4().hex
         queue = asyncio.Queue()
@@ -350,8 +355,11 @@ class RPCClient:
 
             # Read streaming responses
             while True:
-                response = await asyncio.wait_for(queue.get(),
-                                                  timeout=timeout + 1)
+                if timeout is None:
+                    response = await queue.get()
+                else:
+                    response = await asyncio.wait_for(queue.get(),
+                                                      timeout=timeout + 1)
 
                 if response.stream_status == 'start':
                     # Start of stream
@@ -379,7 +387,9 @@ class RPCClient:
     def get_server_attr(self, name: str):
         """ Get the attribute of the RPC server.
         This is mainly used for testing. """
-        return self._call_sync("__rpc_get_attr", name, __rpc_timeout=10)
+        return self._call_sync("__rpc_get_attr",
+                               name,
+                               __rpc_params=RPCParams(timeout=10))
 
     def __getattr__(self, name):
         """
@@ -395,7 +405,8 @@ class RPCClient:
 
             def __call__(self, *args, **kwargs):
                 """Default synchronous call"""
-                mode = kwargs.pop("__rpc_mode", "sync")
+                rpc_params = kwargs.get("__rpc_params", RPCParams())
+                mode = rpc_params.mode
                 if mode == "sync":
                     return self.client._call_sync(self.method_name, *args,
                                                   **kwargs)

--- a/tensorrt_llm/executor/rpc/rpc_common.py
+++ b/tensorrt_llm/executor/rpc/rpc_common.py
@@ -1,6 +1,19 @@
 from typing import Any, Literal, NamedTuple, Optional
 
 
+class RPCParams(NamedTuple):
+    """ Parameters for RPC calls. """
+
+    # seconds to wait for the response
+    timeout: Optional[float] = None
+
+    # whether the client needs the response, if False, it will return immediately
+    need_response: bool = True
+
+    # mode for RPC calls: "sync", "async", or "future"
+    mode: str = "sync"
+
+
 # --- Custom Exceptions ---
 class RPCError(Exception):
     """Custom exception for RPC-related errors raised on the client side.

--- a/tensorrt_llm/executor/rpc/rpc_server.py
+++ b/tensorrt_llm/executor/rpc/rpc_server.py
@@ -118,6 +118,7 @@ class RPCServer:
         logger_debug(
             f"RPC Server shutdown: {self._num_pending_requests} pending requests"
         )
+
         while self._num_pending_requests > 0:
             time.sleep(0.01)
         logger_debug(f"RPC Server shutdown finished pending requests")
@@ -194,10 +195,13 @@ class RPCServer:
 
             await self._queue.put(req)  # type: ignore
 
-            # shutdown is a builtin method depends on _num_pending_requests, so
-            # it should not be counted
-            if req.method_name != "__rpc_shutdown":
+            # shutdown methods depend on _num_pending_requests, so
+            # they should not be counted
+            if req.method_name not in ["__rpc_shutdown", "shutdown"]:
                 self._num_pending_requests += 1
+                logger_debug(
+                    f"Dispatcher received request {req}, pending: {self._num_pending_requests}"
+                )
 
     async def _worker_routine(self, stop_event: threading.Event):
         """The routine executed by each worker thread."""
@@ -213,11 +217,36 @@ class RPCServer:
                 await asyncio.sleep(0)
                 continue
 
-            # Check if this is a streaming request
-            if req.is_streaming and req.method_name in self._functions:
-                func = self._functions[req.method_name]
+            # check if the method name is in the functions
+            if req.method_name not in self._functions:
+                logger.error(
+                    f"Method '{req.method_name}' not found in RPC server.")
+                if not req.need_response:
+                    continue
+                if req.is_streaming:
+                    await self._client_socket.put_async(
+                        RPCResponse(
+                            req.request_id,
+                            None,
+                            RPCStreamingError(
+                                f"Method '{req.method_name}' not found in RPC server.",
+                                traceback=traceback.format_exc()),
+                            stream_status='error'))
+                else:
+                    response = RPCResponse(
+                        req.request_id,
+                        None,
+                        RPCError(
+                            f"Method '{req.method_name}' not found in RPC server.",
+                            traceback=traceback.format_exc()),
+                    )
+                    await self._client_socket.put_async(response)
+
+                continue
+
+            func = self._functions[req.method_name]
+            if req.is_streaming:
                 if inspect.isasyncgenfunction(func):
-                    # Process streaming request
                     await self._process_streaming_request(req)
                 else:
                     # Non-streaming function called with streaming flag
@@ -239,26 +268,25 @@ class RPCServer:
                 # Some tasks don't need response, e.g. submit_request or shutdown
                 if req.need_response and response is not None:
                     logger_debug(
-                        f"RPC Server sending response for request {req}")
+                        f"RPC Server sending response for request {req}, pending: {self._num_pending_requests}"
+                    )
                     await self._client_socket.put_async(response)
                     logger_debug(f"RPC Server sent response for request {req}")
 
-            self._num_pending_requests -= 1
+            # Only decrement if this request was counted in the first place
+            if req.method_name not in ["__rpc_shutdown", "shutdown"]:
+                self._num_pending_requests -= 1
 
     async def _process_request(self, req: RPCRequest) -> Optional[RPCResponse]:
         """Process a request. Returns None for streaming requests (handled separately)."""
-        if req.method_name not in self._functions:
-            return RPCResponse(
-                req.request_id, None,
-                RPCError(f"Method '{req.method_name}' not found in RPC server.",
-                         traceback=traceback.format_exc()))
-
         func = self._functions[req.method_name]
 
         try:
             if inspect.iscoroutinefunction(func):
                 # Execute async function directly in event loop, no need to run in executor due to the GIL
-                logger_debug(f"RPC Server running async task {req.method_name}")
+                logger_debug(
+                    f"RPC Server running async task {req.method_name} in dispatcher"
+                )
                 result = await asyncio.wait_for(func(*req.args, **req.kwargs),
                                                 timeout=req.timeout)
             else:
@@ -268,7 +296,9 @@ class RPCServer:
                 def call_with_kwargs():
                     return func(*req.args, **req.kwargs)
 
-                logger_debug(f"RPC Server running task {req.method_name}")
+                logger_debug(
+                    f"RPC Server running async task {req.method_name} in worker"
+                )
                 result = await asyncio.wait_for(loop.run_in_executor(
                     self._executor, call_with_kwargs),
                                                 timeout=req.timeout)
@@ -292,17 +322,6 @@ class RPCServer:
 
     async def _process_streaming_request(self, req: RPCRequest):
         """Process a streaming request by sending multiple responses."""
-        if req.method_name not in self._functions:
-            await self._client_socket.put_async(
-                RPCResponse(
-                    req.request_id,
-                    None,
-                    RPCStreamingError(
-                        f"Method '{req.method_name}' not found in RPC server.",
-                        traceback=traceback.format_exc()),
-                    stream_status='error'))
-            return
-
         func = self._functions[req.method_name]
 
         if not inspect.isasyncgenfunction(func):

--- a/tensorrt_llm/executor/rpc/rpc_server.py
+++ b/tensorrt_llm/executor/rpc/rpc_server.py
@@ -7,7 +7,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
-from ...llmapi.utils import ManagedThread
+from ...llmapi.utils import ManagedThread, logger_debug
 from ...logger import logger
 from ..ipc import ZeroMqQueue
 from .rpc_common import (RPCError, RPCRequest, RPCResponse, RPCStreamingError,
@@ -22,7 +22,7 @@ class RPCServer:
     def __init__(self,
                  instance,
                  hmac_key=None,
-                 num_workers: int = 1,
+                 num_workers: int = 4,
                  timeout: float = 0.5,
                  async_run_task: bool = False):
         """
@@ -34,6 +34,8 @@ class RPCServer:
             num_workers (int): Number of worker threads.
             timeout (int): Timeout for RPC calls.
             async_run_task (bool): Whether to run the task asynchronously.
+
+        NOTE: make num_workers larger if there are some streaming tasks runs infinitely.
         """
         self._instance = instance
         self._hmac_key = hmac_key
@@ -63,7 +65,8 @@ class RPCServer:
         # Automatically register the instance
         self.register_instance(instance)
 
-        logger.debug(f"RPC Server initialized with {num_workers} workers.")
+        logger_debug(f"RPC Server initialized with {num_workers} workers.",
+                     color="green")
 
     @property
     def address(self) -> str:
@@ -103,7 +106,7 @@ class RPCServer:
         if self._stop_event.is_set():
             return
 
-        logger.debug(
+        logger_debug(
             "RPC Server shutdown signal received. Terminating server...")
 
         # Set the stop event to True, this will trigger the dispatcher routine and
@@ -112,22 +115,22 @@ class RPCServer:
         self._stop_event.set()
 
         # The worker routine should process the pending requests
-        logger.debug(
+        logger_debug(
             f"RPC Server shutdown: {self._num_pending_requests} pending requests"
         )
         while self._num_pending_requests > 0:
             time.sleep(0.01)
-        logger.debug(f"RPC Server shutdown finished pending requests")
+        logger_debug(f"RPC Server shutdown finished pending requests")
 
         if not is_remote_call:
             # Block the thread until shutdown is finished
 
             # 1. Wait for the dispatcher thread to exit, so that no new requests are accepted
-            logger.debug(f"RPC Server dispatcher thread joining")
+            logger_debug(f"RPC Server dispatcher thread joining")
             if self._dispatcher_thread:
                 self._dispatcher_thread.join()
                 self._dispatcher_thread = None
-            logger.debug(f"RPC Server dispatcher thread joined")
+            logger_debug(f"RPC Server dispatcher thread joined")
 
             # 2. Wait for the executor to exit, it will wait for the pending requests to be processed
             if self._executor:
@@ -142,13 +145,13 @@ class RPCServer:
             # if the shutdown is called by a remote call, this method itself will
             # be executed in a executor thread, so we cannot join the dispatcher thread as
             # the dispatcher thread is awaiting for the shutdown result.
-            logger.debug(
+            logger_debug(
                 f"RPC Server to shutdown: {self._num_pending_requests} pending requests"
             )
 
             while self._num_pending_requests > 0:
                 time.sleep(0.01)
-            logger.debug(f"RPC Server shutdown finished pending requests")
+            logger_debug(f"RPC Server shutdown finished pending requests")
 
     def register_function(self, func, name=None):
         """Exposes a single function to clients."""
@@ -157,11 +160,11 @@ class RPCServer:
             logger.warning(
                 f"Function '{fname}' is already registered. Overwriting.")
         self._functions[fname] = func
-        logger.debug(f"Registered function: {fname}")
+        logger_debug(f"Registered function: {fname}")
 
     def register_instance(self, instance):
         """Exposes all public methods of a class instance."""
-        logger.debug(
+        logger_debug(
             f"Registering instance of class: {instance.__class__.__name__}")
         for name in dir(instance):
             if not name.startswith('_'):
@@ -184,7 +187,7 @@ class RPCServer:
             try:
                 req: RPCRequest = await self._client_socket.get_async_noblock(
                     timeout=0.5)
-                logger.debug(f"RPC dispatcher got request: {req}")
+                logger_debug(f"RPC dispatcher got request: {req}")
             except asyncio.TimeoutError:
                 await asyncio.sleep(0)
                 continue
@@ -235,10 +238,10 @@ class RPCServer:
 
                 # Some tasks don't need response, e.g. submit_request or shutdown
                 if req.need_response and response is not None:
-                    logger.debug(
+                    logger_debug(
                         f"RPC Server sending response for request {req}")
                     await self._client_socket.put_async(response)
-                    logger.debug(f"RPC Server sent response for request {req}")
+                    logger_debug(f"RPC Server sent response for request {req}")
 
             self._num_pending_requests -= 1
 
@@ -255,6 +258,7 @@ class RPCServer:
         try:
             if inspect.iscoroutinefunction(func):
                 # Execute async function directly in event loop, no need to run in executor due to the GIL
+                logger_debug(f"RPC Server running async task {req.method_name}")
                 result = await asyncio.wait_for(func(*req.args, **req.kwargs),
                                                 timeout=req.timeout)
             else:
@@ -264,11 +268,12 @@ class RPCServer:
                 def call_with_kwargs():
                     return func(*req.args, **req.kwargs)
 
+                logger_debug(f"RPC Server running task {req.method_name}")
                 result = await asyncio.wait_for(loop.run_in_executor(
                     self._executor, call_with_kwargs),
                                                 timeout=req.timeout)
 
-            logger.debug(f"RPC Server returned result for request {req}")
+            logger_debug(f"RPC Server returned result for request {req}")
             response = RPCResponse(req.request_id, result)
 
         except asyncio.TimeoutError:
@@ -315,6 +320,7 @@ class RPCServer:
         sequence_number = 0
 
         try:
+            logger_debug(f"RPC Server running streaming task {req.method_name}")
             # Send start signal
             await self._client_socket.put_async(
                 RPCResponse(req.request_id, None, None, True, sequence_number,
@@ -323,6 +329,8 @@ class RPCServer:
 
             # Stream the results
             async for result in func(*req.args, **req.kwargs):
+                logger_debug(
+                    f"RPC Server got data and ready to send result {result}")
                 await self._client_socket.put_async(
                     RPCResponse(req.request_id, result, None, True,
                                 sequence_number, 'data'))

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -14,6 +14,7 @@ from .postproc_worker import PostprocWorkerConfig
 from .request import GenerationRequest
 from .result import GenerationResult
 from .rpc import RPCClient
+from .rpc.rpc_common import RPCParams
 from .rpc_worker import RpcWorker
 from .utils import (ErrorResponse, create_mpi_comm_session,
                     get_spawn_proxy_process_env, is_llm_response)
@@ -90,7 +91,8 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
         clock = 0
         while not self._shutdown_event.is_set():
             if clock % 1 == 0:
-                responses = self.fetch_responses_remote()
+                responses = self.fetch_responses_remote(
+                )  # RPC request => RPC server; result => RPC client
                 self.handle_responses(responses)
             if clock % 10 == 0:
                 stats = self.fetch_stats_remote()  # TODO
@@ -144,7 +146,8 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
         logprob_params = self._get_logprob_params(request)
 
         # submit is a fire-and-forget operation, don't need to wait for response
-        self.rpc_client.submit(request, __rpc_need_response=False)
+        self.rpc_client.submit(request,
+                               __rpc_params=RPCParams(need_response=False))
 
         result = GenerationResult(
             request,
@@ -157,16 +160,19 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
         return result
 
     def fetch_responses_remote(self):
-        return self.rpc_client.fetch_responses(__rpc_timeout=20)
+        return self.rpc_client.fetch_responses(__rpc_params=RPCParams(
+            timeout=20))
 
     def fetch_stats_remote(self):
         return self.rpc_client.fetch_stats()
 
     def setup_engine_remote(self):
-        return self.rpc_client.setup_engine(__rpc_timeout=60 * 20)  # 20 min
+        return self.rpc_client.setup_engine(
+            __rpc_params=RPCParams(timeout=60 * 20))  # 20 min
 
     def shutdown_remote(self):
-        self.rpc_client.shutdown(__rpc_timeout=60 * 20)  # 20 min
+        self.rpc_client.shutdown(__rpc_params=RPCParams(timeout=60 *
+                                                        20))  # 20 min
 
     def abort_request(self, request_id: int) -> None:
         return self.rpc_client.abort_request(request_id)

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -1,3 +1,4 @@
+import asyncio
 import atexit
 import os
 import threading
@@ -6,7 +7,7 @@ from typing import Optional
 
 from ..llmapi.mpi_session import MpiPoolSession, MpiSession
 from ..llmapi.tracer import global_tracer
-from ..llmapi.utils import (_SyncQueue, print_colored_debug,
+from ..llmapi.utils import (_SyncQueue, logger_debug, print_colored_debug,
                             print_traceback_on_error)
 from ..logger import logger
 from .executor import GenerationExecutor
@@ -84,25 +85,23 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
                                 **self.worker_kwargs)
 
     @print_traceback_on_error
-    def main_loop_task(self):
+    async def main_loop_task(self):
         """
         Main loop of the proxy, it will invoke the actions periodically.
         """
-        clock = 0
-        while not self._shutdown_event.is_set():
-            if clock % 1 == 0:
-                responses = self.fetch_responses_remote(
-                )  # RPC request => RPC server; result => RPC client
-                self.handle_responses(responses)
-            if clock % 10 == 0:
-                stats = self.fetch_stats_remote()  # TODO
-                self.handle_stats(stats)
-
-            clock += 1
-            time.sleep(self.clock_unit)
+        async for responses in self.rpc_client.fetch_responses_loop_async.call_streaming(
+        ):
+            if self._shutdown_event.is_set():
+                return
+            self.handle_responses(responses)
 
     def setup_mainloop(self):
-        self.main_loop_thread = threading.Thread(target=self.main_loop_task,
+
+        def _run_main_loop_task():
+            """Local method to run the main loop task."""
+            asyncio.run(self.main_loop_task())
+
+        self.main_loop_thread = threading.Thread(target=_run_main_loop_task,
                                                  daemon=True)
         self.main_loop_thread.start()
         atexit.register(self.shutdown)
@@ -167,12 +166,12 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
         return self.rpc_client.fetch_stats()
 
     def setup_engine_remote(self):
-        return self.rpc_client.setup_engine(
-            __rpc_params=RPCParams(timeout=60 * 20))  # 20 min
+        return self.rpc_client.setup_engine(__rpc_params=RPCParams(
+            need_response=True))
 
     def shutdown_remote(self):
-        self.rpc_client.shutdown(__rpc_params=RPCParams(timeout=60 *
-                                                        20))  # 20 min
+        logger_debug(f"Shutting down rpc remote", color="yellow")
+        self.rpc_client.shutdown()
 
     def abort_request(self, request_id: int) -> None:
         return self.rpc_client.abort_request(request_id)
@@ -180,13 +179,15 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
     def shutdown(self):
         if self._shutdown_event.is_set():
             return
+        logger_debug(f"Shutting down GenerationExecutorRpcProxy",
+                     color="yellow")
 
-        # 1. stop the main loop, so that no new rpc requests
+        # 1. shutdown the rpc server (PyExecutor Rank 0 + RPC server)
+        self.shutdown_remote()
+
+        # 2. stop the main loop, so that no new rpc requests
         self._shutdown_event.set()
         self.main_loop_thread.join()
-
-        # 2. shutdown the rpc server (PyExecutor Rank 0 + RPC server)
-        self.shutdown_remote()
 
         # 3. shutdown the mpi session, this should wait until all the PyExecutor
         # processes are shutdown

--- a/tensorrt_llm/executor/rpc_worker.py
+++ b/tensorrt_llm/executor/rpc_worker.py
@@ -57,8 +57,8 @@ class RpcWorker(WorkerBase):
                      color="yellow")
         # NOTE: This is a blocking call, it will wait for the responses to be available.
         super().await_responses(timeout)
-        logger_debug(f"RpcWorker returning responses", color="yellow")
         qsize = self._response_queue.qsize()
+        logger_debug(f"RpcWorker returning {qsize} responses", color="yellow")
         return [self._response_queue.get() for _ in range(qsize)]
 
     async def fetch_responses_async(self) -> list:

--- a/tensorrt_llm/executor/rpc_worker.py
+++ b/tensorrt_llm/executor/rpc_worker.py
@@ -4,6 +4,7 @@ from queue import Queue
 from threading import Event
 from typing import AsyncGenerator, Optional, Union
 
+from tensorrt_llm._utils import mpi_comm
 from tensorrt_llm.llmapi.utils import enable_llm_debug, logger_debug
 
 from .._utils import mpi_rank
@@ -80,6 +81,12 @@ class RpcWorker(WorkerBase):
             f"RpcWorker {mpi_rank()} quitting fetch_responses_loop_async",
             color="yellow")
 
+    def setup_engine(self):
+        # Force all the ranks to wait here, and start creating the executor simultaneously.
+        mpi_comm().barrier()
+
+        super().setup_engine()
+
     def shutdown(self):
         logger_debug(f"RPC worker {mpi_rank()} is shutting down",
                      color="yellow")
@@ -111,8 +118,6 @@ class RpcWorker(WorkerBase):
             garbage_collection_gen0_threshold=garbage_collection_gen0_threshold)
 
         if mpi_rank() != 0:
-            logger_debug(f"Worker {mpi_rank()} is setting up the engine",
-                         color="yellow")
             # The non-leader worker will setup the engine immediately.
             # The leader worker will wait for the RPC call to propagate the
             # potential error.
@@ -125,7 +130,7 @@ class RpcWorker(WorkerBase):
                          color="yellow")
             # Step 2: Create the RPC service, it will expose all the APIs of the worker as remote call to the client
             # Set num_workers to larger than 1 since there are some streaming tasks runs infinitely, such as await_responses_async.
-            rpc_server = RPCServer(worker, num_workers=4)
+            rpc_server = RPCServer(worker, num_workers=6)
             rpc_server.bind(rpc_addr)
             rpc_server.start()
 

--- a/tensorrt_llm/executor/rpc_worker.py
+++ b/tensorrt_llm/executor/rpc_worker.py
@@ -1,14 +1,15 @@
+import asyncio
 from pathlib import Path
 from queue import Queue
 from threading import Event
-from typing import Optional, Union
+from typing import AsyncGenerator, Optional, Union
 
-from tensorrt_llm.llmapi.utils import enable_llm_debug
+from tensorrt_llm.llmapi.utils import enable_llm_debug, logger_debug
 
 from .._utils import mpi_rank
 from ..bindings import executor as tllm
 from ..builder import Engine
-from ..logger import logger, set_level
+from ..logger import set_level
 from ..lora_manager import LoraConfig
 from ..sampling_params import BatchedLogitsProcessor
 from .postproc_worker import PostprocWorkerConfig
@@ -50,16 +51,38 @@ class RpcWorker(WorkerBase):
     def fetch_stats(self) -> list:
         return super().fetch_stats()
 
-    def fetch_responses(self) -> list:
-        logger.debug(f"RpcWorker {mpi_rank()} is fetching responses")
+    def fetch_responses(self, timeout: Optional[float] = None) -> list:
+        logger_debug(f"RpcWorker {mpi_rank()} is fetching responses",
+                     color="yellow")
         # NOTE: This is a blocking call, it will wait for the responses to be available.
-        super().await_responses()
-        logger.debug(f"RpcWorker returning responses")
+        super().await_responses(timeout)
+        logger_debug(f"RpcWorker returning responses", color="yellow")
         qsize = self._response_queue.qsize()
         return [self._response_queue.get() for _ in range(qsize)]
 
+    async def fetch_responses_async(self) -> list:
+        return await asyncio.to_thread(self.fetch_responses)
+
+    # for streaming performance
+    async def fetch_responses_loop_async(self) -> AsyncGenerator[list, None]:
+        while not self.shutdown_event.is_set():
+            responses = await asyncio.to_thread(self.fetch_responses
+                                                )  # run blocking call in thread
+            if responses:  # Only yield if there are actual responses
+                logger_debug(
+                    f"RpcWorker {mpi_rank()} is yielding responses: {responses}",
+                    color="yellow")
+                yield responses  # batching the responses to opt IPC performance
+            else:
+                # Small delay to prevent busy waiting when no responses
+                await asyncio.sleep(0)
+        logger_debug(
+            f"RpcWorker {mpi_rank()} quitting fetch_responses_loop_async",
+            color="yellow")
+
     def shutdown(self):
-        logger.debug(f"RPC worker {mpi_rank()} is shutting down")
+        logger_debug(f"RPC worker {mpi_rank()} is shutting down",
+                     color="yellow")
         self.shutdown_event.set()
         super().shutdown()
 
@@ -88,22 +111,26 @@ class RpcWorker(WorkerBase):
             garbage_collection_gen0_threshold=garbage_collection_gen0_threshold)
 
         if mpi_rank() != 0:
-            logger.debug(f"Worker {mpi_rank()} is setting up the engine")
+            logger_debug(f"Worker {mpi_rank()} is setting up the engine",
+                         color="yellow")
             # The non-leader worker will setup the engine immediately.
             # The leader worker will wait for the RPC call to propagate the
             # potential error.
-            logger.debug(f"Worker {mpi_rank()} is setting up the engine")
+            logger_debug(f"Worker {mpi_rank()} is setting up the engine",
+                         color="yellow")
             worker.setup_engine()
 
         if mpi_rank() == 0:
-            logger.debug(f"Worker {mpi_rank()} is creating the RPC service")
+            logger_debug(f"Worker {mpi_rank()} is creating the RPC service",
+                         color="yellow")
             # Step 2: Create the RPC service, it will expose all the APIs of the worker as remote call to the client
-            rpc_server = RPCServer(worker)
+            # Set num_workers to larger than 1 since there are some streaming tasks runs infinitely, such as await_responses_async.
+            rpc_server = RPCServer(worker, num_workers=4)
             rpc_server.bind(rpc_addr)
             rpc_server.start()
 
             # Step 3: Wait for the worker to shutdown
-            logger.debug(
+            logger_debug(
                 f"Worker {mpi_rank()} is waiting for the worker to shutdown")
             worker.shutdown_event.wait()
             rpc_server.shutdown()

--- a/tensorrt_llm/executor/worker_base.py
+++ b/tensorrt_llm/executor/worker_base.py
@@ -17,7 +17,7 @@ from ..bindings import executor as tllm
 from ..builder import ConfigEncoder, Engine, EngineConfig
 from ..llmapi.llm_args import PybindMirror
 from ..llmapi.tracer import global_tracer
-from ..llmapi.utils import _SyncQueue, print_colored_debug
+from ..llmapi.utils import _SyncQueue, logger_debug, print_colored_debug
 from ..logger import logger
 from ..lora_manager import LoraConfig, LoraManager
 from ..metrics import RequestEventTiming
@@ -142,6 +142,7 @@ class WorkerBase(GenerationExecutor):
             else:
                 raise ValueError(
                     f"Unsupported backend config: {executor_config.backend}")
+
             self.engine = create_executor(**args)
 
         self._setup_lora(engine, executor_config, self._lora_config)
@@ -468,16 +469,23 @@ class WorkerBase(GenerationExecutor):
         self._client_id_to_request_id.pop(client_id, None)
 
     def shutdown(self):
-        if self.engine is not None:
-            if self.engine.can_enqueue_requests():
-                self.engine.shutdown()
-                self.engine = None
+        if self.engine is None:
+            return
 
-            if hasattr(
-                    self._executor_config, "checkpoint_loader"
-            ) and self._executor_config.checkpoint_loader is not None:
-                self._executor_config.checkpoint_loader.cleanup()
-                self._executor_config.checkpoint_loader = None
+        logger_debug(f"WorkerBase {self.rank} is shutting down", color="yellow")
+        if self.engine.can_enqueue_requests():
+            self.engine.shutdown()
+            self.engine = None
+
+        if hasattr(self._executor_config, "checkpoint_loader"
+                   ) and self._executor_config.checkpoint_loader is not None:
+            self._executor_config.checkpoint_loader.cleanup()
+            self._executor_config.checkpoint_loader = None
+
+        self.engine = None
+
+        logger_debug(f"WorkerBase {self.rank} shutdown done", color="yellow")
+
         # Check if there are any errors from the threads before shutdown.
         self._handle_background_error()
 

--- a/tensorrt_llm/executor/worker_base.py
+++ b/tensorrt_llm/executor/worker_base.py
@@ -92,6 +92,11 @@ class WorkerBase(GenerationExecutor):
         self._runtime_model_config: Optional[ModelConfig] = None
 
     def setup_engine(self) -> None:
+        logger_debug(f"WorkerBase {self.rank} is setting up the engine",
+                     color="yellow")
+
+        # Force all the ranks to wait here, and start creating the executor simultaneously.
+        mpi_comm().barrier()
 
         device_id = self.global_rank % torch.cuda.device_count()
         torch.cuda.set_device(device_id)
@@ -143,7 +148,13 @@ class WorkerBase(GenerationExecutor):
                 raise ValueError(
                     f"Unsupported backend config: {executor_config.backend}")
 
+            logger_debug(f"WorkerBase {self.rank} creating py_executor",
+                         color="yellow")
             self.engine = create_executor(**args)
+            logger_debug(f"WorkerBase {self.rank} created py_executor",
+                         color="yellow")
+        logger_debug(f"WorkerBase {self.rank} setup engine done",
+                     color="yellow")
 
         self._setup_lora(engine, executor_config, self._lora_config)
 

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -1,6 +1,8 @@
 import asyncio
 import collections
+import datetime
 import hashlib
+import inspect
 import io
 import os
 import sys
@@ -63,8 +65,61 @@ def print_colored(message,
 def print_colored_debug(message,
                         color: Optional[str] = None,
                         writer: io.TextIOWrapper = sys.stderr):
-    if enable_llm_debug():
+    if enable_llmapi_debug():
         print_colored(message, color, writer)
+
+
+def get_current_location(skip_frames: int = 2) -> str:
+    """
+    Get the current execution location in format 'module.class.function'.
+
+    Args:
+        skip_frames: Number of stack frames to skip (default 2 to skip this function and its caller)
+
+    Returns:
+        String in format 'module.class.function' or 'module.function' if not in a class
+    """
+    stack = inspect.stack()
+    if len(stack) <= skip_frames:
+        return "unknown"
+
+    frame = stack[skip_frames]
+    module_name = frame.frame.f_globals.get('__name__', 'unknown')
+    function_name = frame.function
+
+    # Try to determine if we're in a class method
+    class_name = None
+    if 'self' in frame.frame.f_locals:
+        # This is likely an instance method
+        obj = frame.frame.f_locals['self']
+        class_name = obj.__class__.__name__
+    elif 'cls' in frame.frame.f_locals:
+        # This might be a class method
+        cls = frame.frame.f_locals['cls']
+        if inspect.isclass(cls):
+            class_name = cls.__name__
+
+    # Build the location string
+    if class_name:
+        return f"{module_name}.{class_name}.{function_name}"
+    else:
+        return f"{module_name}.{function_name}"
+
+
+def logger_debug(message,
+                 color: Optional[str] = None,
+                 writer: io.TextIOWrapper = sys.stderr):
+    """ Print the message if the llmapi debug mode is enabled. Fallback to logger.debug if not. """
+    if enable_llmapi_debug():
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        location = get_current_location()
+        cur_dualname = "..." + location[-47:] if len(
+            location) > 50 else location
+        print_colored(f"{timestamp} [{cur_dualname}]", "bold_green", writer)
+        print_colored(f" {message}\n", color, writer)
+    else:
+        # Fallback to logger.debug
+        logger.debug(message)
 
 
 def file_with_glob_exists(directory, glob) -> bool:
@@ -287,6 +342,17 @@ def enable_llm_debug() -> bool:
     if _enable_llm_debug_ is None:
         _enable_llm_debug_ = os.environ.get("TLLM_LLM_ENABLE_DEBUG", "0") == "1"
     return _enable_llm_debug_
+
+
+_enable_llmapi_debug_ = None
+
+
+def enable_llmapi_debug() -> bool:
+    global _enable_llmapi_debug_
+    if _enable_llmapi_debug_ is None:
+        _enable_llmapi_debug_ = os.environ.get("TLLM_LLMAPI_ENABLE_DEBUG",
+                                               "0") == "1"
+    return _enable_llmapi_debug_
 
 
 @cache

--- a/tests/unittest/executor/test_rpc.py
+++ b/tests/unittest/executor/test_rpc.py
@@ -505,7 +505,7 @@ class TestApp:
             yield i
 
 
-class TestRpcStreaming:
+class TestRpcAsync:
     # Use setup_method/teardown_method for pytest class-based setup/teardown
     def setup_method(self):
         """Setup RPC server and client for tests."""

--- a/tests/unittest/executor/test_rpc.py
+++ b/tests/unittest/executor/test_rpc.py
@@ -4,7 +4,8 @@ import time
 import pytest
 
 from tensorrt_llm.executor.rpc import (RPCCancelled, RPCClient, RPCError,
-                                       RPCServer, RPCStreamingError, RPCTimeout)
+                                       RPCParams, RPCServer, RPCStreamingError,
+                                       RPCTimeout)
 
 
 class RpcServerWrapper(RPCServer):
@@ -126,7 +127,7 @@ class TestRpcBasics:
         with RpcServerWrapper(App(),
                               addr="ipc:///tmp/rpc_test_no_wait") as server:
             with RPCClient("ipc:///tmp/rpc_test_no_wait") as client:
-                client.send_task(__rpc_need_response=False)
+                client.send_task(__rpc_params=RPCParams(need_response=False))
                 time.sleep(
                     0.1
                 )  # wait for some time to make sure the task is submitted
@@ -209,7 +210,8 @@ class TestRpcError:
         with RPCClient(addr) as client:
             client.shutdown_server()
             pending_futures = [
-                client.task(__rpc_mode="future") for _ in range(10)
+                client.task(__rpc_params=RPCParams(mode="future"))
+                for _ in range(10)
             ]
 
             for future in pending_futures:
@@ -238,7 +240,7 @@ class TestRpcError:
             with RPCClient("ipc:///tmp/rpc_test_timeout",
                            timeout=0.5) as client:
                 with pytest.raises(RPCError) as exc_info:
-                    client.slow_method(__rpc_timeout=0.5)
+                    client.slow_method(__rpc_params=RPCParams(timeout=0.5))
 
                     error = exc_info.value
                     # Should be either a timeout error or RPC error indicating timeout
@@ -306,14 +308,14 @@ def test_rpc_without_response_performance():
         with RPCClient("ipc:///tmp/rpc_test_no_wait") as client:
             time_start = time.time()
             for i in range(100):
-                client.send_task(__rpc_need_response=False)
+                client.send_task(__rpc_params=RPCParams(need_response=False))
             time_end = time.time()
 
             no_wait_time = time_end - time_start
 
             time_start = time.time()
             for i in range(100):
-                client.send_task(__rpc_need_response=True)
+                client.send_task(__rpc_params=RPCParams(need_response=True))
             time_end = time.time()
             wait_time = time_end - time_start
 
@@ -340,7 +342,8 @@ def test_rpc_benchmark(async_run_task: bool, use_ipc_addr: bool):
 
             time_start = time.time()
             for i in range(100):
-                ret = client.cal(i, __rpc_timeout=10)  # sync call
+                ret = client.cal(
+                    i, __rpc_params=RPCParams(timeout=10))  # sync call
                 assert ret == i * 2, f"{ret} != {i * 2}"
             time_end = time.time()
             print(
@@ -378,7 +381,7 @@ class TestRpcTimeout:
 
     def run_sync_timeout_test(self):
         with pytest.raises(RPCTimeout) as exc_info:
-            self.client.slow_operation(2.0, __rpc_timeout=0.1)
+            self.client.slow_operation(2.0, __rpc_params=RPCParams(timeout=0.1))
         assert "timed out" in str(
             exc_info.value), f"Timeout message not found: {exc_info.value}"
 
@@ -387,16 +390,16 @@ class TestRpcTimeout:
 
         async def async_timeout():
             with pytest.raises(RPCTimeout) as exc_info:
-                await self.client.call_async('slow_operation',
-                                             2.0,
-                                             __rpc_timeout=0.1)
+                await self.client.call_async(
+                    'slow_operation', 2.0, __rpc_params=RPCParams(timeout=0.1))
             assert "timed out" in str(
                 exc_info.value), f"Timeout message not found: {exc_info.value}"
 
         asyncio.run(async_timeout())
 
     def run_sync_success_test(self):
-        result = self.client.slow_operation(0.1, __rpc_timeout=10.0)
+        result = self.client.slow_operation(
+            0.1, __rpc_params=RPCParams(timeout=10.0))
         assert result == "completed"
         print(f"final result: {result}")
 
@@ -404,9 +407,8 @@ class TestRpcTimeout:
         import asyncio
 
         async def async_success():
-            result = await self.client.call_async('slow_operation',
-                                                  0.1,
-                                                  __rpc_timeout=10.0)
+            result = await self.client.call_async(
+                'slow_operation', 0.1, __rpc_params=RPCParams(timeout=10.0))
             assert result == "completed"
             print(f"final result: {result}")
             return result
@@ -457,7 +459,8 @@ class TestRpcShutdown:
         time.sleep(0.1)
         with RPCClient("ipc:///tmp/rpc_test_shutdown") as client:
             # This task should be continued after server shutdown
-            res = client.foo(10, __rpc_timeout=12, __rpc_mode="future")
+            res = client.foo(10,
+                             __rpc_params=RPCParams(timeout=12, mode="future"))
 
             # The shutdown will block until all pending requests are finished
             server.shutdown()
@@ -589,7 +592,7 @@ class TestRpcStreaming:
         # Set short timeout
         with pytest.raises(RPCTimeout):
             async for value in client.streaming_timeout.call_streaming(
-                    delay=2.0, __rpc_timeout=0.5):
+                    delay=2.0, __rpc_params=RPCParams(timeout=0.5)):
                 pass  # Should timeout before first yield
 
     @pytest.mark.asyncio

--- a/tests/unittest/executor/test_rpc_proxy.py
+++ b/tests/unittest/executor/test_rpc_proxy.py
@@ -1,6 +1,8 @@
 import os
 import sys
+import time
 
+import pytest
 from test_worker_base import create_fake_executor_config
 
 from tensorrt_llm.executor.rpc_proxy import GenerationExecutorRpcProxy
@@ -17,24 +19,34 @@ from utils.util import similar
 model_path = llm_models_root() / "llama-models-v2/TinyLlama-1.1B-Chat-v1.0"
 
 
-class TestRpcProxyTp1:
-
-    def setup_method(self):
-        self.executor_config = create_fake_executor_config(model_path)
+class TestRpcProxy:
 
     def create_proxy(self, tp_size: int):
+        # Create executor config with the correct tp_size
+        executor_config = create_fake_executor_config(model_path,
+                                                      tp_size=tp_size)
+
         mpi_session = MpiPoolSession(n_workers=tp_size)
         proxy = GenerationExecutorRpcProxy(
             worker_kwargs={
                 "engine": model_path,
-                "executor_config": self.executor_config,
+                "executor_config": executor_config,
                 "model_world_size": tp_size,
             },
+            model_world_size=tp_size,
             mpi_session=mpi_session,
         )
+
+        # Add additional wait for PyTorch backend with multi-rank setup
+        if tp_size > 1:
+            print(f"[Test] Waiting for {tp_size} ranks to initialize...")
+            time.sleep(
+                5)  # Give more time for multi-rank PyTorch initialization
+
         return proxy
 
-    def test_tp1(self):
+    @pytest.mark.parametrize("num_reqs", [1, 10])
+    def test_tp1(self, num_reqs):
         tokenizer = TransformersTokenizer.from_pretrained(model_path)
         prompt = "A B C D"
         prompt_token_ids = tokenizer.encode(prompt)
@@ -42,7 +54,23 @@ class TestRpcProxyTp1:
 
         with self.create_proxy(tp_size=1) as proxy:
             sampling_params = SamplingParams(max_tokens=max_tokens)
-            result = proxy.generate(prompt_token_ids, sampling_params)
+            for _ in range(num_reqs):
+                result = proxy.generate(prompt_token_ids, sampling_params)
+                print(f"get result: {result}")
+                assert similar(tokenizer.decode(result.outputs[0].token_ids),
+                               'E F G H I J K L')
+
+    @pytest.mark.parametrize("num_reqs", [1, 10])
+    def test_tp2(self, num_reqs):
+        tokenizer = TransformersTokenizer.from_pretrained(model_path)
+        prompt = "A B C D"
+        prompt_token_ids = tokenizer.encode(prompt)
+        max_tokens = 8
+
+        with self.create_proxy(tp_size=2) as proxy:
+            sampling_params = SamplingParams(max_tokens=max_tokens)
+            for _ in range(num_reqs):
+                result = proxy.generate(prompt_token_ids, sampling_params)
             print(f"get result: {result}")
             assert similar(tokenizer.decode(result.outputs[0].token_ids),
                            'E F G H I J K L')

--- a/tests/unittest/executor/test_rpc_worker.py
+++ b/tests/unittest/executor/test_rpc_worker.py
@@ -1,13 +1,15 @@
+import asyncio
 import multiprocessing
 import os
 import sys
 import time
 from concurrent.futures import ProcessPoolExecutor
 
+import pytest
 from test_worker_base import create_fake_executor_config
 
 from tensorrt_llm.executor.request import GenerationRequest
-from tensorrt_llm.executor.rpc import RPCClient
+from tensorrt_llm.executor.rpc import RPCClient, RPCParams
 from tensorrt_llm.executor.rpc_proxy import GenerationExecutorRpcProxy
 from tensorrt_llm.executor.rpc_worker import RpcWorker
 from tensorrt_llm.sampling_params import SamplingParams
@@ -20,15 +22,24 @@ from utils.llm_data import llm_models_root
 model_path = llm_models_root() / "llama-models-v2/TinyLlama-1.1B-Chat-v1.0"
 
 
-class TestRpcWorker:
+class TestRpcWorkerTP1:
 
     def setup_method(self):
         self.executor_config = create_fake_executor_config(model_path)
+        self.pool, self.addr = self.create_tp1_worker_process()
+        self.client = self.create_rpc_client(self.addr)
+        self.client.setup_engine()
+        time.sleep(10)
 
-    def create_tp1_worker_process(self):
+    def teardown_method(self):
+        self.client.shutdown()
+        self.pool.shutdown()
+        self.client.close()
+
+    def create_worker_pool(self):
         addr = GenerationExecutorRpcProxy.gen_uniq_rpc_addr()
-        # Use spawn method instead of fork
-        mp_context = multiprocessing.get_context('spawn')
+        mp_context = multiprocessing.get_context(
+            'spawn')  # spawn for CUDA context
         pool = ProcessPoolExecutor(max_workers=1, mp_context=mp_context)
         pool.submit(RpcWorker.main_task,
                     engine=model_path,
@@ -40,17 +51,94 @@ class TestRpcWorker:
         client = RPCClient(addr)
         return client
 
+    def test_create_shutdown(self):
+        pass
+
+    def test_fetch_responses_sync(self):
+        self.client.submit(GenerationRequest(
+            prompt_token_ids=[3, 4, 5],
+            sampling_params=SamplingParams(max_tokens=5)),
+                           __rpc_params=RPCParams(need_response=False))
+        results = self.client.fetch_responses()
+        assert len(results) == 1
+
+    def test_fetch_responses_streaming_sync(self):
+        self.client.submit(GenerationRequest(
+            prompt_token_ids=[3, 4, 5],
+            sampling_params=SamplingParams(max_tokens=5),
+            streaming=True),
+                           __rpc_params=RPCParams(need_response=False))
+
+        results = []
+        for i in range(10):
+            res = self.client.fetch_responses()
+            results.extend(res)
+            print(f"fetch_responses {i} result: {results}")
+        assert 0 < len(results) <= 5
+
+        time.sleep(5)
+
+    @pytest.mark.asyncio
+    async def test_fetch_responses_streaming_async(self):
+        self.client.submit(GenerationRequest(
+            prompt_token_ids=[3, 4, 5],
+            sampling_params=SamplingParams(max_tokens=5),
+            streaming=True),
+                           __rpc_params=RPCParams(need_response=False))
+
+        results = []
+        # Must fetch all the responses, or the PyExecutor will hang
+        for i in range(10):
+            res = await self.client.fetch_responses_async.call_async()
+            results.extend(res)
+            print(f"fetch_responses_async {i} result: {results}")
+        assert 0 < len(results) <= 5
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("req_count", [10])
+    async def test_main_loop_async(self, req_count: int):
+        await asyncio.sleep(1)
+
+        async def process_request_streaming():
+            for i in range(req_count):
+                ret = self.client.submit(
+                    GenerationRequest(
+                        prompt_token_ids=[3, 4, 5],
+                        sampling_params=SamplingParams(max_tokens=5),
+                        streaming=True),
+                    __rpc_params=RPCParams(need_response=False))
+                assert ret is None
+                print("submit result: ", ret)
+
+            # NOTE: known issue, the responses should be fetched before shutdown,
+            # or the shutdown will hang.
+            results = []
+
+            print(f"start to fetch_responses_async")
+            no = 0
+            async for result in self.client.fetch_responses_loop_async.call_streaming(
+            ):
+                print(f"fetch_responses_async {no} result: {result}")
+                results.extend(result)  # result is a list of responses
+                no += 1
+                if no >= req_count * 5:  # Break after receiving 5 batches
+                    print(f"break after receiving {no} batches")
+                    break
+            print(f"Received {no} batches of streaming responses")
+            print(f"fetch_responses result: {results}")
+            assert results
+
+        await process_request_streaming()
+
     def test_main_loop(self):
-        pool, addr = self.create_tp1_worker_process()
-        client = self.create_rpc_client(addr)
-        client.setup_engine(__rpc_timeout=120)
         time.sleep(1)
 
         def process_request():
-            ret = client.submit(GenerationRequest(
-                prompt_token_ids=[3, 4, 5],
-                sampling_params=SamplingParams(max_tokens=10)),
-                                __rpc_need_response=False)
+            ret = self.client.submit(
+                GenerationRequest(
+                    prompt_token_ids=[3, 4, 5],
+                    sampling_params=SamplingParams(max_tokens=10)),
+                __rpc_params=RPCParams(need_response=False))
             assert ret is None  # need_response = False
 
             print(f"submit result: {ret}")
@@ -60,16 +148,16 @@ class TestRpcWorker:
             results = []
             time.sleep(8)  # wait for PyExecutor to finish the generation
             results.extend(
-                client.fetch_responses())  # fetch_responses will block
+                self.client.fetch_responses())  # fetch_responses will block
             print(f"fetch_responses result: {results}")
             assert len(results) == 1  # one request, one response
 
         def process_request_streaming():
-            ret = client.submit(GenerationRequest(
-                prompt_token_ids=[3, 4, 5],
-                sampling_params=SamplingParams(max_tokens=10),
-                streaming=True),
-                                __rpc_need_response=False)
+            ret = self.client.submit(
+                GenerationRequest(prompt_token_ids=[3, 4, 5],
+                                  sampling_params=SamplingParams(max_tokens=10),
+                                  streaming=True),
+                __rpc_params=RPCParams(need_response=False))
             assert ret is None
             print("submit result: ", ret)
 
@@ -80,7 +168,9 @@ class TestRpcWorker:
 
             while not results:
                 time.sleep(1)
-                results.extend(client.fetch_responses(__rpc_timeout=10))
+                results.extend(
+                    self.client.fetch_responses(__rpc_params=RPCParams(
+                        timeout=10)))
                 print(f"try fetch_responses result: {results}")
             print(f"fetch_responses result: {results}")
             assert results
@@ -89,12 +179,43 @@ class TestRpcWorker:
             process_request()
         process_request_streaming()
 
-        print("call shutdown")
-        client.shutdown(__rpc_timeout=10)
-        pool.shutdown()
-        client.close()
 
+class TestRpcWorkerTP2:
 
-if __name__ == '__main__':
-    worker = TestRpcWorker()
-    worker.test_main_loop()
+    def setup_method(self):
+        self.executor_config = create_fake_executor_config(model_path)
+        self.pool, self.addr = self.create_worker_pool()
+        self.client = self.create_rpc_client(self.addr)
+        self.client.setup_engine()
+        time.sleep(10)
+
+    def teardown_method(self):
+        self.client.shutdown()
+        self.pool.shutdown()
+        self.client.close()
+
+    def create_worker_pool(self):
+        addr = GenerationExecutorRpcProxy.gen_uniq_rpc_addr()
+        mp_context = multiprocessing.get_context(
+            'spawn')  # spawn for CUDA context
+        pool = ProcessPoolExecutor(max_workers=2, mp_context=mp_context)
+        pool.submit(RpcWorker.main_task,
+                    engine=model_path,
+                    rpc_addr=addr,
+                    executor_config=self.executor_config)
+        return pool, addr
+
+    def create_rpc_client(self, addr: str):
+        client = RPCClient(addr)
+        return client
+
+    def test_create_shutdown(self):
+        pass
+
+    def test_fetch_responses_sync(self):
+        self.client.submit(GenerationRequest(
+            prompt_token_ids=[3, 4, 5],
+            sampling_params=SamplingParams(max_tokens=5)),
+                           __rpc_params=RPCParams(need_response=False))
+        results = self.client.fetch_responses()
+        assert len(results) == 1

--- a/tests/unittest/executor/test_rpc_worker.py
+++ b/tests/unittest/executor/test_rpc_worker.py
@@ -12,6 +12,7 @@ from tensorrt_llm.executor.request import GenerationRequest
 from tensorrt_llm.executor.rpc import RPCClient, RPCParams
 from tensorrt_llm.executor.rpc_proxy import GenerationExecutorRpcProxy
 from tensorrt_llm.executor.rpc_worker import RpcWorker
+from tensorrt_llm.llmapi.mpi_session import MpiPoolSession
 from tensorrt_llm.sampling_params import SamplingParams
 
 # isort: off
@@ -26,7 +27,7 @@ class TestRpcWorkerTP1:
 
     def setup_method(self):
         self.executor_config = create_fake_executor_config(model_path)
-        self.pool, self.addr = self.create_tp1_worker_process()
+        self.pool, self.addr = self.create_worker_pool()
         self.client = self.create_rpc_client(self.addr)
         self.client.setup_engine()
         time.sleep(10)
@@ -183,33 +184,34 @@ class TestRpcWorkerTP1:
 class TestRpcWorkerTP2:
 
     def setup_method(self):
-        self.executor_config = create_fake_executor_config(model_path)
-        self.pool, self.addr = self.create_worker_pool()
+        self.executor_config = create_fake_executor_config(model_path,
+                                                           tp_size=2)
+        self.session, self.addr, self.futures = self.create_worker_session()
         self.client = self.create_rpc_client(self.addr)
         self.client.setup_engine()
         time.sleep(10)
 
     def teardown_method(self):
         self.client.shutdown()
-        self.pool.shutdown()
+        self.session.shutdown()
         self.client.close()
 
-    def create_worker_pool(self):
+    def create_worker_session(self):
+        session = MpiPoolSession(n_workers=2)
         addr = GenerationExecutorRpcProxy.gen_uniq_rpc_addr()
-        mp_context = multiprocessing.get_context(
-            'spawn')  # spawn for CUDA context
-        pool = ProcessPoolExecutor(max_workers=2, mp_context=mp_context)
-        pool.submit(RpcWorker.main_task,
-                    engine=model_path,
-                    rpc_addr=addr,
-                    executor_config=self.executor_config)
-        return pool, addr
+        futures = session.submit(RpcWorker.main_task,
+                                 engine=model_path,
+                                 rpc_addr=addr,
+                                 executor_config=self.executor_config,
+                                 model_world_size=2)
+        return session, addr, futures
 
     def create_rpc_client(self, addr: str):
-        client = RPCClient(addr)
-        return client
+        return RPCClient(addr)
 
     def test_create_shutdown(self):
+        # Invoke setup_engine in rank 0, and that will unblock all the ranks to
+        # invoke setup_engine simultaneously.
         pass
 
     def test_fetch_responses_sync(self):


### PR DESCRIPTION
Fix the test_rpc_worker.py and test_rpc_proxy.py.

Refactor the RPC usage from
```
rpc_client.remote_method(...args, __rpc_params=RPCParams(...))
```
to
```
rpc_client.remote_method(...args).remote(...rpc_params)
```

Introduce `log_debug` for LLM-API sepcific debugging logging.